### PR TITLE
Improved connection handling

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,3 @@
 {deps, [
-    {lhttpc, ".*", {git, "git://github.com/esl/lhttpc.git", {branch, "master"}}},
     {statman, "", {git, "git://github.com/knutin/statman.git", {branch, "master"}}}
     ]}.

--- a/src/statman_graphite_app.erl
+++ b/src/statman_graphite_app.erl
@@ -10,11 +10,6 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    ok = application:ensure_started(asn1),
-    ok = application:ensure_started(crypto),
-    ok = application:ensure_started(public_key),
-    ok = application:ensure_started(ssl),
-    ok = application:ensure_started(lhttpc),
     ok = application:ensure_started(statman),
 
     statman_graphite_sup:start_link().


### PR DESCRIPTION
This patch makes statman_graphite_pusher connect to graphite only when needed and avoids blocking startup of the whole node.

I also removed lhttpc which wasn't used anymore.
